### PR TITLE
Two fixes for rbenv/homebrew path issues

### DIFF
--- a/lib/rbenv_setup.rb
+++ b/lib/rbenv_setup.rb
@@ -32,7 +32,7 @@ class RbenvSetup
   end
 
   def rbenv(command)
-    `sh -l -c 'rbenv #{command}'`
+    `#{shell} -i -c 'rbenv #{command}'`
   end
 
   def rbenv_is_a_function?
@@ -55,6 +55,6 @@ class RbenvSetup
   end
 
   def update_gems!
-    system %Q|sh -l -c 'eval "$(rbenv init -)" && gem update --silent --system'|
+    rbenv 'exec gem update --silent --system'
   end
 end


### PR DESCRIPTION
I found these when reviewing #1, `sh -l` will get you a login shell, but `sh` doesn't parse your shell-specific rc files, so even though it's been added to "your" shell, you won't have `rbenv` in your path unless your homebrew prefix is in your path.