### PR TITLE
Refactor setup classes to use class methods

### DIFF
--- a/cmd/umts-dev-setup.rb
+++ b/cmd/umts-dev-setup.rb
@@ -16,21 +16,9 @@ module Homebrew
   module_function
 
   def umts_dev_setup
-    setup_brew_path
-    setup_nodenv
-    setup_rbenv
+    BrewPathSetup.setup!
+    NodenvSetup.setup!
+    RbenvSetup.setup!
     puts "\e[92mYou will need to restart your shell for some changes to take effect.\e[0m"
-  end
-
-  def setup_nodenv
-    NodenvSetup.new.setup!
-  end
-
-  def setup_rbenv
-    RbenvSetup.new.setup!
-  end
-
-  def setup_brew_path
-    BrewPathSetup.new.setup!
   end
 end

--- a/lib/brew_path_setup.rb
+++ b/lib/brew_path_setup.rb
@@ -3,30 +3,32 @@
 require_relative 'shell_utils'
 
 class BrewPathSetup
-  include ShellUtils
+  extend ShellUtils
 
-  def setup!
-    setup_shell!
-  end
-
-  private
-
-  def brew_is_in_path?
-    case shell
-    when 'zsh'
-      /^brew: command$/.match? `zsh -i -c 'whence -w brew'`
-    when 'bash'
-      /^file$/.match? `bash -l -c 'type -t brew'`
-    else
-      false
+  class << self
+    def setup!
+      setup_shell!
     end
-  end
 
-  def setup_shell!
-    return if brew_is_in_path?
+    private
 
-    rcfile.open('a') do |f|
-      f.puts %|eval "$(#{HOMEBREW_PREFIX.to_s.chomp}/bin/brew shellenv)"|
+    def brew_is_in_path?
+      case shell
+      when 'zsh'
+        /^brew: command$/.match? `zsh -i -c 'whence -w brew'`
+      when 'bash'
+        /^file$/.match? `bash -l -c 'type -t brew'`
+      else
+        false
+      end
+    end
+
+    def setup_shell!
+      return if brew_is_in_path?
+
+      rcfile.open('a') do |f|
+        f.puts %|eval "$(#{HOMEBREW_PREFIX.to_s.chomp}/bin/brew shellenv)"|
+      end
     end
   end
 end

--- a/lib/nodenv_setup.rb
+++ b/lib/nodenv_setup.rb
@@ -3,30 +3,32 @@
 require_relative 'shell_utils'
 
 class NodenvSetup
-  include ShellUtils
+  extend ShellUtils
 
-  def setup!
-    setup_shell!
-  end
-
-  private
-
-  def nodenv_is_a_function?
-    case shell
-    when 'zsh'
-      /^nodenv: function$/.match? `zsh -i -c 'whence -w nodenv'`
-    when 'bash'
-      /^function$/.match? `bash -l -c 'type -t nodenv'`
-    else
-      false
+  class << self
+    def setup!
+      setup_shell!
     end
-  end
 
-  def setup_shell!
-    return if nodenv_is_a_function?
+    private
 
-    rcfile.open('a') do |f|
-      f.puts 'eval "$(nodenv init -)"'
+    def nodenv_is_a_function?
+      case shell
+      when 'zsh'
+        /^nodenv: function$/.match? `zsh -i -c 'whence -w nodenv'`
+      when 'bash'
+        /^function$/.match? `bash -l -c 'type -t nodenv'`
+      else
+        false
+      end
+    end
+
+    def setup_shell!
+      return if nodenv_is_a_function?
+
+      rcfile.open('a') do |f|
+        f.puts 'eval "$(nodenv init -)"'
+      end
     end
   end
 end

--- a/lib/rbenv_setup.rb
+++ b/lib/rbenv_setup.rb
@@ -4,62 +4,64 @@ require 'rubygems'
 require_relative 'shell_utils'
 
 class RbenvSetup
-  include ShellUtils
+  extend ShellUtils
 
-  def setup!
-    setup_shell!
-    install_ruby!
-    global_version!
-    update_gems!
-  end
-
-  private
-
-  def global_version!
-    home.join('.rbenv', 'version').then do |gf|
-      gf.dirname.mkdir unless gf.dirname.exist?
-      gf.write "#{ruby_version}\n" unless gf.exist?
+  class << self
+    def setup!
+      setup_shell!
+      install_ruby!
+      global_version!
+      update_gems!
     end
-  end
 
-  def install_ruby!
-    rbenv "install --skip-existing #{ruby_version}"
-    rbenv 'rehash'
-  end
+    private
 
-  def ruby_version
-    @ruby_version ||= rbenv('install --list').split.grep(/^[0-9.]+$/).max_by do |v|
-      Gem::Version.new(v)
+    def global_version!
+      home.join('.rbenv', 'version').then do |gf|
+        gf.dirname.mkdir unless gf.dirname.exist?
+        gf.write "#{ruby_version}\n" unless gf.exist?
+      end
     end
-  end
 
-  def rbenv(command)
-    paths = ENV.fetch('PATH', '').split(':').unshift(HOMEBREW_PREFIX.join('bin').to_s).uniq
-    IO.popen({ 'PATH' => paths.join(':') }, "#{shell} -i -c 'rbenv #{command}'") do |io|
-      io.read.strip
+    def install_ruby!
+      rbenv "install --skip-existing #{ruby_version}"
+      rbenv 'rehash'
     end
-  end
 
-  def rbenv_is_a_function?
-    case shell
-    when 'zsh'
-      /^rbenv: function$/.match? `zsh -i -c 'whence -w rbenv'`
-    when 'bash'
-      /^function$/.match? `bash -l -c 'type -t rbenv'`
-    else
-      false
+    def ruby_version
+      @ruby_version ||= rbenv('install --list').split.grep(/^[0-9.]+$/).max_by do |v|
+        Gem::Version.new(v)
+      end
     end
-  end
 
-  def setup_shell!
-    return if rbenv_is_a_function?
-
-    rcfile.open('a') do |f|
-      f.puts %|eval "$(rbenv init - #{shell})"|
+    def rbenv(command)
+      paths = ENV.fetch('PATH', '').split(':').unshift(HOMEBREW_PREFIX.join('bin').to_s).uniq
+      IO.popen({ 'PATH' => paths.join(':') }, "#{shell} -i -c 'rbenv #{command}'") do |io|
+        io.read.strip
+      end
     end
-  end
 
-  def update_gems!
-    rbenv 'exec gem update --silent --system'
+    def rbenv_is_a_function?
+      case shell
+      when 'zsh'
+        /^rbenv: function$/.match? `zsh -i -c 'whence -w rbenv'`
+      when 'bash'
+        /^function$/.match? `bash -l -c 'type -t rbenv'`
+      else
+        false
+      end
+    end
+
+    def setup_shell!
+      return if rbenv_is_a_function?
+
+      rcfile.open('a') do |f|
+        f.puts %|eval "$(rbenv init - #{shell})"|
+      end
+    end
+
+    def update_gems!
+      rbenv 'exec gem update --silent --system'
+    end
   end
 end


### PR DESCRIPTION
This is entirely just a code style/refactor PR, but this has bugged me while working on this repo. TL;DR:
- Two levels of redirection in `cmd/umts-dev-setup` is not needed
- We never create more than one instance, and we only use that one instance one time